### PR TITLE
fix(download): make extended version download work

### DIFF
--- a/cmd/vela-hugo/hugo.go
+++ b/cmd/vela-hugo/hugo.go
@@ -88,8 +88,11 @@ func install(extendedBinary bool, customVer, defaultVer string) error {
 	// into semantic version struct
 	ver, err := semver.NewVersion(customVer)
 	if err != nil {
-		logrus.Errorf("not a valid version: %s", customVer)
+		return fmt.Errorf("not a valid version: %s", customVer)
 	}
+
+	// allow version usage with and without leading 'v'
+	customVer = strings.TrimPrefix(customVer, "v")
 
 	// let user know that a custom version
 	// was requested

--- a/cmd/vela-hugo/hugo.go
+++ b/cmd/vela-hugo/hugo.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/hashicorp/go-getter"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -58,28 +59,57 @@ func install(extendedBinary bool, customVer, defaultVer string) error {
 		archType = "unsupported"
 	}
 
-	versionMatch := strings.EqualFold(customVer, defaultVer)
-
-	// check if the custom version matches the default version and/or the extneded binary is requested
-	if versionMatch && !extendedBinary {
-		// the hugo versions match and using the base hugo binary so no action is required
-		return nil
-	}
-
-	if !versionMatch {
-		logrus.Infof("custom version does not match default: %s", defaultVer)
-	}
-
+	// change the binary file name
+	// if the extended version for Sass/SCSS support
+	// has been requested
 	if extendedBinary {
 		logrus.Infof("using extended hugo binary")
 
 		binary = "hugo_extended"
 	}
 
+	// check if the custom version requested
+	// is the default version
+	isDefaultVersion := strings.EqualFold(customVer, defaultVer)
+
+	// check if the custom version matches the default version and/or the extneded binary is requested
+	if isDefaultVersion && !extendedBinary {
+		// the hugo versions match and using the base hugo binary so no action is required
+		return nil
+	}
+
+	// use default version if no custom version
+	// was requested
+	if len(customVer) == 0 {
+		customVer = defaultVer
+	}
+
+	// try to parse the version
+	// into semantic version struct
+	ver, err := semver.NewVersion(customVer)
+	if err != nil {
+		logrus.Errorf("not a valid version: %s", customVer)
+	}
+
+	// let user know that a custom version
+	// was requested
+	if !isDefaultVersion && len(customVer) > 0 {
+		logrus.Infof("custom version requested (default is: %s): %s", defaultVer, customVer)
+	}
+
+	// special handling for macOS.
+	// starting with 0.102, hugo supplies
+	// a fat universal binary
+	//
+	// see notes here: https://github.com/gohugoio/hugo/releases/tag/v0.102.0
+	if osName == "macOS" && ver.Minor() > uint64(101) {
+		archType = "universal"
+	}
+
 	// rename the old hugo binary since we can't overwrite it for now
 	//
 	// https://github.com/hashicorp/go-getter/issues/219
-	err := a.Rename(_hugo, fmt.Sprintf("%s.default", _hugo))
+	err = a.Rename(_hugo, fmt.Sprintf("%s.default", _hugo))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
this fixes an issue with downloads not working if `extended: true` was used _without_ specifying a custom `version`. this fix also accounts for the unlikely scenario that you are requesting macOS binaries for versions 0.102.0+ due to the hugo project changing release asset naming.

also includes a small enhancement to allow `vX.Y.Z` or `X.Y.Z` for overriding the version